### PR TITLE
Quote variables

### DIFF
--- a/tasks/section_02_level1.yml
+++ b/tasks/section_02_level1.yml
@@ -91,7 +91,7 @@
       - section2.17.1
 
   - name: 2.17.2 Set Sticky Bit on All World-Writable Directories (Scored)
-    file: path={{ item }} mode="a+t"
+    file: path='{{ item }}' mode="a+t"
     with_items: sticky_bit_dirs.stdout_lines
     tags:
       - section2

--- a/tasks/section_03_level1.yml
+++ b/tasks/section_03_level1.yml
@@ -93,7 +93,7 @@
       - section3.4.1
 
   - name: 3.4.2 Require Authentication for Single-User Mode (Scored)
-    user: name=root state=present password={{ root_password }}
+    user: name=root state=present password='{{ root_password }}'
     when: root_password_set.rc == 1
     tags:
       - section3

--- a/tasks/section_08_level1.yml
+++ b/tasks/section_08_level1.yml
@@ -67,7 +67,7 @@
       - section8
       - section8.2
       - section8.2.3
-  
+
   - name: 8.2.4.1 Create and Set Permissions on rsyslog Log Files (Scored)
     shell: awk '{ print $NF }' /etc/rsyslog.d/* /etc/rsyslog.conf | grep /var/log | sed 's/^-//' | sed 's/)$//' 
     register: result
@@ -89,7 +89,7 @@
 
   - name: 8.2.4.3 Create and Set Permissions on rsyslog Log Files (Scored)
     file: >
-        path={{item}}  
+        path='{{item}}' 
         owner=root 
         group=root 
         mode="og-rwx" 

--- a/tasks/section_08_level2.yml
+++ b/tasks/section_08_level2.yml
@@ -101,7 +101,7 @@
   - name: 8.1.4 Record Events That Modify Date and Time Information (Scored)
     lineinfile: >
       dest=/etc/audit/audit.rules
-      line={{ item }}
+      line='{{ item }}'
       state=present
       create=yes
     with_items:
@@ -235,7 +235,7 @@
   - name: 8.1.12 Collect Use of Privileged Commands (infos) (Scored)
     lineinfile: >
         dest=/etc/audit/audit.rules
-        line={{ item }}
+        line='{{ item }}'
         state=present
         create=yes
     with_items: audit_lines_for_find.stdout_lines

--- a/tasks/section_12_level1.yml
+++ b/tasks/section_12_level1.yml
@@ -46,7 +46,7 @@
       - section12.7
 
   - name: 12.7 Find World Writable Files (Not Scored)
-    debug: msg={{ item }}
+    debug: msg='{{ item }}'
     with_items:
         world_files.stdout_lines
     tags:
@@ -63,7 +63,7 @@
       - section12.8
 
   - name: 12.8 Find Un-owned Files and Directories (Scored)
-    debug: msg={{ item }}
+    debug: msg='{{ item }}'
     with_items:
         unowned_files.stdout_lines
     tags:
@@ -80,7 +80,7 @@
       - section12.9
 
   - name: 12.9 Find Un-grouped Files and Directories (Scored)
-    debug: msg={{ item }}
+    debug: msg='{{ item }}'
     with_items:
         ungrouped_files.stdout_lines
     tags:
@@ -97,7 +97,7 @@
       - section12.10
 
   - name: 12.10 Find SUID System Executables (Not Scored)
-    debug: msg={{ item }}
+    debug: msg='{{ item }}'
     with_items:
         suid_files.stdout_lines
     tags:
@@ -114,7 +114,7 @@
       - section12.11
 
   - name: 12.11 Find SGID System Executables (Not Scored)
-    debug: msg={{ item }}
+    debug: msg='{{ item }}'
     with_items:
         gsuid_files.stdout_lines
     tags:

--- a/tasks/section_13_level1.yml
+++ b/tasks/section_13_level1.yml
@@ -10,7 +10,7 @@
       - section13.1
 
   - name: 13.1 Ensure Password Fields are Not Empty (locking accounts) (Scored)
-    command: passwd -l {{ item }}
+    command: passwd -l '{{ item }}'
     with_items:
         awk_empty_shadow.stdout_lines
     when: lock_shadow_accounts
@@ -83,7 +83,7 @@
 
   - name: 13.6.4 Ensure root PATH Integrity (Scored)
     file: >
-        path={{ item }}
+        path='{{ item }}'
         state=directory
         owner=root
         mode='o-w,g-w'
@@ -104,7 +104,7 @@
 
   - name: 13.7.2 Check Permissions on User Home Directories (Scored)
     file: >
-        path={{ item }}
+        path='{{ item }}'
         mode='g-w,o-rwx'
         state=directory
     with_items:
@@ -126,7 +126,7 @@
 
   - name: 13.8.2 Check User Dot File Permissions (Scored)
     file: >
-        path={{ item }}
+        path='{{ item }}'
         mode='o-w,g-w'
     with_items:
         home_dot_files.stdout_lines
@@ -136,7 +136,7 @@
 
   - name: 13.9 Check Permissions on User .netrc Files (Scored)
     file: >
-        path={{ item }}/.netrc
+        path='{{ item }}/.netrc'
         mode='g-rwx,o-rwx'
         recurse=yes
         state=directory
@@ -149,7 +149,7 @@
   - name: 13.10 Check for Presence of User .rhosts Files (Scored)
     file: >
         state=absent
-        path={{ item }}/.rhosts
+        path='{{ item }}/.rhosts'
     with_items:
         home_users.stdout_lines
     tags:
@@ -177,7 +177,7 @@
       - section13.11
 
   - name: 13.12 Check That Users Are Assigned Valid Home Directories (Scored)
-    stat: path={{ item }}
+    stat: path='{{ item }}'
     with_items:
         home_users.stdout_lines
     register: rstat


### PR DESCRIPTION
This PR fixes the two issues reported at #8. Quotes variables that may contain equal signs (user names and file names in particular).
