### PR TITLE
Boolean variable for partitioning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,6 @@
 # This variable defines if accounts without password have to be locked
 lock_shadow_accounts: no
-partitioning: false
+partitioning: False
 
 # Default root password: root
 root_password: $6$5Mklo2YKvXOM50Zj$E8w4oiykpG9WiElxwHLx85rFFFG0z/lu0vp0wiU0SAnMnw0CmYhmArxvLxBjWQ6XVHv88XQyfpTjX4CPH89hf1

--- a/tasks/section_02_level1.yml
+++ b/tasks/section_02_level1.yml
@@ -8,7 +8,7 @@
 
   - name: 2.2 - 4 Set nodev, nosuid, noexec option for /tmp Partition (Scored)
     mount: name="/tmp" state="mounted" opts="nodev,nosuid,noexec"
-    when: partitioning=="true"
+    when: partitioning == True
     tags:
       - section2
       - section2.2
@@ -23,7 +23,7 @@
 
   - name: 2.6 Bind Mount the /var/tmp directory to /tmp (Scored)
     mount: name="/var/tmp" src="/tmp" opts=bind state=mounted
-    when: partitioning=="true"
+    when: partitioning == True
     tags:
       - section2
       - section2.6
@@ -48,7 +48,7 @@
 
   - name: 2.10 Add nodev Option to /home (Scored)
     mount: name:/home state:mounted opts:remount,nodev
-    when: partitioning=="true"
+    when: partitioning == True
     tags:
       - section2
       - section2.10


### PR DESCRIPTION
Doesn't seem to work otherwise. Looks like both `True` and `true` are translated to boolean variables by Ansible.
