### PR TITLE
Variable to skip /run/shm remount

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,3 +32,6 @@ restrict_core_dumps: True
 
 # Disable all ipv6 interfaces. Suggested if the protocol is not used.
 disable_ipv6: True
+
+# True if run/shm is write-protected.
+run_shm_read_only: False

--- a/tasks/section_02_level1.yml
+++ b/tasks/section_02_level1.yml
@@ -73,6 +73,7 @@
 
   - name: 2.14 - 16 Add nodev Option to /run/shm Partition (Scored)
     mount: name="/run/shm" src="/run/shm" state="mounted" opts="nodev,nosuid,noexec" fstype="tmpfs"
+    when: run_shm_read_only == False
     tags:
       - section2
       - section2.14

--- a/tests/main.yml
+++ b/tests/main.yml
@@ -32,3 +32,6 @@ restrict_core_dumps: False
 
 # Disable all ipv6 interfaces. Suggested if the protocol is not used.
 disable_ipv6: False
+
+# True if run/shm is write-protected.
+run_shm_read_only: False


### PR DESCRIPTION
This pull request adds a new variable to allow skipping /run/shm remount (in case it's write-protected)
I currently use it for [the Drone.io build](https://drone.io/github.com/pchaigno/cis-ubuntu-ansible) (I change the value on the fly before launching the build).

@awailly Is there a way to do better? Maybe remount in read-only mode if it's write-protected?
