### PR TITLE
Code coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 CIS for Ubuntu 14.04
 ====================
 
-[![Build Status](https://travis-ci.org/awailly/cis-ubuntu-ansible.svg?branch=master)](https://travis-ci.org/awailly/cis-ubuntu-ansible)[![Documentation Status](https://readthedocs.org/projects/cis-ubuntu-ansible/badge/?version=latest)](https://readthedocs.org/projects/cis-ubuntu-ansible/?badge=latest)
+[![Build Status](https://travis-ci.org/awailly/cis-ubuntu-ansible.svg?branch=master)](https://travis-ci.org/awailly/cis-ubuntu-ansible)  [![Documentation Status](https://readthedocs.org/projects/cis-ubuntu-ansible/badge/?version=latest)](https://readthedocs.org/projects/cis-ubuntu-ansible/?badge=latest)  [![Code coverage](https://drone.io/github.com/awailly/cis-ubuntu-ansible/files/coverage.png)](https://drone.io/github.com/awailly/cis-ubuntu-ansible)
 
 Usage
 -----


### PR DESCRIPTION
This pull request adds a badge for the code coverage percentage (currently at 27% :grimacing:).
The badge points to your build on Drone.io @awailly so you'll have to set it up.
You'll need to copy my settings and add `./coverage.png` in your artifact settings too.

See [my fork](https://github.com/pchaigno/cis-ubuntu-ansible/tree/test-code-coverage-badge#cis-for-ubuntu-1404) for a preview.

I think the percentage would be more accurate if we were to count tasks with a changed item instead of all changed items. Some of the tasks impact a lot of items (see [tasks 2.17.2](https://drone.io/github.com/pchaigno/cis-ubuntu-ansible/files/results.txt) for instance). It would probably require to write a script though :/
