### PR TITLE
Option to not enable ALSR

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,3 +38,6 @@ run_shm_read_only: False
 
 # Set this flag if the kernel has TCP syncookies support.
 enable_tcp_syncookies: True
+
+# Set this flag to randomize virtual memory region placement.
+enable_aslr: True

--- a/tasks/section_04_level1.yml
+++ b/tasks/section_04_level1.yml
@@ -73,6 +73,7 @@
        name=kernel.randomize_va_space
        value=2
        state=present
+    when: enable_aslr
     tags:
       - section4
       - section4.3


### PR DESCRIPTION
I need this option for Debian 8 in Docker:

```
TASK: [cis-ubuntu-ansible | 4.3 Enable Randomized Virtual Memory Region Placement (Scored)] *** 
failed: [localhost] => {"failed": true}
msg: Failed to reload sysctl: sysctl: setting key "kernel.randomize_va_space": Read-only file system
```
