### PR TITLE
Change rsyslog variable name for better behavior explanation - Fixes #56

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,7 +55,7 @@ max_log_file_auditd: 200
 
 # Set this flag if you have a remote rsyslog server to send logs.
 # WARNING: Update the IP address or rsyslog will hit 100% of the CPU usage.
-send_rsyslog_remote: False
+set_rsyslog_remote: False
 
 # Set rsyslog's logs remote server address to send logs. 
 # WARNING: Update the IP address or rsyslog will hit 100% of the CPU usage

--- a/tasks/section_08_level1.yml
+++ b/tasks/section_08_level1.yml
@@ -116,7 +116,7 @@
        line="*.* @@{{remote_logs_host_address}}"
        insertafter=EOF
        state=present
-    when: send_rsyslog_remote == True and remoteloghost.rc == 1
+    when: set_rsyslog_remote == True and remoteloghost.rc == 1
     tags:
       - section8
       - section8.2
@@ -142,7 +142,7 @@
     with_items:
         - '$ModLoad imtcp'
         - '$InputTCPServerRun 514'
-    when: send_rsyslog_remote == True and moadloadpresent.rc == 1
+    when: set_rsyslog_remote == True and moadloadpresent.rc == 1
     changed_when: False
     notify: restart rsyslog
     tags:

--- a/tests/travis_defaults.yml
+++ b/tests/travis_defaults.yml
@@ -11,4 +11,4 @@ restrict_core_dumps: False
 disable_ipv6: False
 
 # Not loosing coverage.
-send_rsyslog_remote: True
+set_rsyslog_remote: True


### PR DESCRIPTION
Fixes #56 with a better variable name.
Does not integrate the full rollback feature.
