### PR TITLE
Command line utility for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ sudo pip install ansible markupsafe
 
 The following will automatically install Ansible, download and run the playbook on your local system.
 ```
-$ \curl -sSL http://git.io/vZw8S | bash
+$ \curl -sSL http://git.io/vZw8S > /tmp/cis.sh && bash /tmp/cis.sh
 ```
 To apply the playbook on a remote system:
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,18 @@ $ sudo pip install ansible markupsafe
 
 ## Usage
 
-### Setting up the environment
+### One liner installation & execution
+
+The following will automatically install Ansible, download and run the playbook on your local system.
+```
+$ curl -sSL http://git.io/vZw8S | bash
+```
+To apply the playbook on a remote system:
+```
+$ IP=[remote host's IP] USER=[remote user] curl -sSL http://git.io/vZw8S | bash
+```
+
+### Manual installation
 
 Create a placeholder to describe your machine:
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,6 @@
 
 The role is focused on hardening an Ubuntu 14.04 system. However it has been successfully tested on other Debian based systems (Debian 8, Raspbian). The minimum requirements of the targeted system are `ssh`, `aptitude` and `python2`.
 
-Install dependencies on your host (on Ubuntu 14.04):
-
-```bash
-$ sudo apt-get install python-pip git python-dev
-$ sudo pip install ansible markupsafe
-```
-
 ## Usage
 
 ### One liner installation & execution
@@ -31,6 +24,13 @@ $ IP=[remote host's IP] USER=[remote user] \curl -sSL http://git.io/vZw8S | bash
 ```
 
 ### Manual installation
+
+Install dependencies on your host (on Ubuntu 14.04):
+
+```bash
+$ sudo apt-get install python-pip git python-dev
+$ sudo pip install ansible markupsafe
+```
 
 Create a placeholder to describe your machine:
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ $ sudo pip install ansible markupsafe
 
 The following will automatically install Ansible, download and run the playbook on your local system.
 ```
-$ curl -sSL http://git.io/vZw8S | bash
+$ \curl -sSL http://git.io/vZw8S | bash
 ```
 To apply the playbook on a remote system:
 ```
-$ IP=[remote host's IP] USER=[remote user] curl -sSL http://git.io/vZw8S | bash
+$ IP=[remote host's IP] USER=[remote user] \curl -sSL http://git.io/vZw8S | bash
 ```
 
 ### Manual installation


### PR DESCRIPTION
We mentioned at some point (probably on IRC though) that we could have a Bash script for deployment distributed with the [releases](https://github.com/awailly/cis-ubuntu-ansible/releases).

The goal is to have a simple command line utility for users who want to test this without the _burden_ of installing Ansible, reading the documentation, etc. So the script should install everything, set up the environment and present clear choices to the user (such as Desktop/Server, Remote log/Local logs).

I'm opening this issue to see what this script should do exactly.
What I listed so far:
- [x] Download the repository.
- [x] [Set up the environment](https://github.com/awailly/cis-ubuntu-ansible#setting-up-the-environment).
- [x] Install Ansible and aptitude if needed.
- [x] Tune the environment (or it could assume that its a default Desktop config):
  - Desktop/Server (`remove_xserver`)
  - Remote logs (`send_rsyslog_remote`)
  - Is the system partitioned? (`partitioning`)
- [x] Run the playbook.
