### PR TITLE
Add follow=yes when checking dot file permissions in 13.8.2 so the ta…

### DIFF
--- a/tasks/section_13_level1.yml
+++ b/tasks/section_13_level1.yml
@@ -127,6 +127,7 @@
   - name: 13.8.2 Check User Dot File Permissions (Scored)
     file: >
         path='{{ item }}'
+        follow=yes
         mode='o-w,g-w'
     with_items:
         home_dot_files.stdout_lines


### PR DESCRIPTION
…sk does not error for symlinks

Closes #78
