### PR TITLE
Fix rsyslog parsing

### DIFF
--- a/tasks/section_08_level1.yml
+++ b/tasks/section_08_level1.yml
@@ -69,7 +69,7 @@
       - section8.2.3
 
   - name: 8.2.4.1 Create and Set Permissions on rsyslog Log Files (Scored)
-    shell: awk '{ print $NF }' /etc/rsyslog.d/* /etc/rsyslog.conf | grep /var/log | sed 's/^-//' | sed 's/)$//' 
+    shell: awk '{ print $NF }' /etc/rsyslog.d/* /etc/rsyslog.conf | grep -oiP "/var/log/[\w\.-]+"
     register: result
     changed_when: False
     always_run: True

--- a/tests/setup-tests.sh
+++ b/tests/setup-tests.sh
@@ -45,6 +45,12 @@ sudo chmod 777 /etc/hosts.deny
 
 #Prepare section 08
 sudo chmod 777 /etc/rsyslog.conf
+cat >> /etc/rsyslog.d/30-marathon.conf << 'EOF'
+if $programname == 'marathon' then {
+  action(type="omfile" asyncWriting="on" file="/var/log/marathon.log")
+  stop
+}
+EOF
 
 #Prepare section 13
 #section13.1


### PR DESCRIPTION
This pull request addresses the issue reported in #86.
<br>

In 8.2.4.1, the current regexp is only capable of parsing simple rsyslog configurations, such as:

``` shell
:msg,contains,"[UFW " /var/log/ufw.log
```

It fails with "more advanced" configurations, such as:

``` shell
if $programname == 'marathon' then {
  action(type="omfile" asyncWriting="on" file="/var/log/marathon.log")
  stop
}
```

<br>

The new regexp is more generic in that it extracts any reference to a file in `/var/log/`.
I also added a test case in `tests/setup-tests.sh` (for Travis) from #86. The result can be seen in the Travis builds of this pull request: the first commit -- with the test case -- breaks the Travis build, while the second -- with the new regexp -- fixes it.
