### PR TITLE
Remove Drone.io from the CIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # CIS for Ubuntu 14.04
 
 [![Build Status](https://travis-ci.org/awailly/cis-ubuntu-ansible.svg?branch=master)](https://travis-ci.org/awailly/cis-ubuntu-ansible)
-[![Build Status](https://drone.io/github.com/awailly/cis-ubuntu-ansible/status.png)](https://drone.io/github.com/awailly/cis-ubuntu-ansible/latest)
 [![Documentation Status](https://readthedocs.org/projects/cis-ubuntu-ansible/badge/?version=latest)](https://readthedocs.org/projects/cis-ubuntu-ansible/?badge=latest)
-[![Code coverage](https://drone.io/github.com/awailly/cis-ubuntu-ansible/files/coverage.png?version=latest)](https://drone.io/github.com/awailly/cis-ubuntu-ansible)
 [![Coverage Status](https://coveralls.io/repos/awailly/cis-ubuntu-ansible/badge.svg?branch=master)](https://coveralls.io/r/awailly/cis-ubuntu-ansible?branch=master)
 
 ## Prerequisites

--- a/tests/drone_defaults.yml
+++ b/tests/drone_defaults.yml
@@ -1,2 +1,0 @@
-# True if run/shm is write-protected.
-run_shm_read_only: True


### PR DESCRIPTION
Builds on Drone.io have been failing for several months now because of an issue with their packages.
I tried to contact them several weeks ago, and got no answer.

@awailly I think you'll need to remove Drone.io's access to the repository (in `Settings > Webhooks & services`).
