### PR TITLE
Allow to override the group of rsyslog log files in 8.2.4: resolves #93

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,8 +70,9 @@ max_log_file_auditd: 200
 # WARNING: Update the IP address or rsyslog will hit 100% of the CPU usage.
 set_rsyslog_remote: False
 
-# Override to change the group of log files in 8.2.4 (eg, to 'adm')
+# Override to change the group and permissions of log files in 8.2.4 (eg, to 'adm' and 'g-wx,o-rwx' respectively)
 rsyslog_log_files_group: root
+rsyslog_log_files_permissions: og-rwx
 
 # Set rsyslog's logs remote server address to send logs. 
 # WARNING: Update the IP address without localhost address or rsyslog will hit 100% of the CPU usage

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,12 +70,16 @@ max_log_file_auditd: 200
 # WARNING: Update the IP address or rsyslog will hit 100% of the CPU usage.
 set_rsyslog_remote: False
 
+# Override to change the group of log files in 8.2.4 (eg, to 'adm')
+rsyslog_log_files_group: root
+
 # Set rsyslog's logs remote server address to send logs. 
 # WARNING: Update the IP address without localhost address or rsyslog will hit 100% of the CPU usage
 remote_logs_host_address: X.X.X.X
 
 # Set this flag to use AIDE. Disable when using another file integrity checker like OSSEC.
 use_aide: True
+
 
 
 # Section 09

--- a/tasks/section_08_level1.yml
+++ b/tasks/section_08_level1.yml
@@ -92,7 +92,7 @@
     file:
         path: "{{ item }}"
         owner: root 
-        group: root 
+        group: "{{ rsyslog_log_files_group }}"
         mode: "og-rwx" 
     when: "(rsyslog_files_created.results|length > 0) and ('skipped' not in rsyslog_files_created.results[0])"
     with_items: result.stdout_lines

--- a/tasks/section_08_level1.yml
+++ b/tasks/section_08_level1.yml
@@ -93,9 +93,10 @@
         path: "{{ item }}"
         owner: root 
         group: "{{ rsyslog_log_files_group }}"
-        mode: "og-rwx" 
+        mode: "{{ rsyslog_log_files_permissions }}"
     when: "(rsyslog_files_created.results|length > 0) and ('skipped' not in rsyslog_files_created.results[0])"
     with_items: result.stdout_lines
+    notify: restart rsyslog
     tags:
       - section8
       - section8.2


### PR DESCRIPTION
Allow to override the group of rsyslog log files in 8.2.4: resolves #93
