### PR TITLE
Modprobe.d ubuntu 16.04

### DIFF
--- a/tasks/section_07_level1.yml
+++ b/tasks/section_07_level1.yml
@@ -275,6 +275,15 @@
       - section7.4
       - section7.4.5
 
+  - name: 7.5.0 Ensures /etc/modprobe.d/ exists (Not Scored)
+    file: >
+        path=/etc/modprobe.d
+        state=directory
+    register: cis_conf_file
+    tags:
+      - section7
+      - section7.5
+
   - name: 7.5.1-4 Disable DCCP, SCTP, RDS, TIPC (Not Scored)
     lineinfile: >
         dest=/etc/modprobe.d/CIS.conf

--- a/tasks/section_07_level1.yml
+++ b/tasks/section_07_level1.yml
@@ -275,30 +275,12 @@
       - section7.4
       - section7.4.5
 
-  - name: 7.5.0 Create the file "cis.conf" under modprobe.d if doesn't exist (Not Scored)
-    copy:
-        dest: /etc/modprobe.d/CIS.conf
-        content: ""
-        force: no
-    tags:
-      - section7
-      - section7.5
-
-  - name: 7.5.0 Check the presence of the file "cis.conf" under modprobe.d (Not Scored)
-    stat: >
-        path=/etc/modprobe.d/CIS.conf
-    register: cis_conf_file
-    tags:
-      - section7
-      - section7.5
-
-
   - name: 7.5.1-4 Disable DCCP, SCTP, RDS, TIPC (Not Scored)
     lineinfile: >
         dest=/etc/modprobe.d/CIS.conf
         line='install {{ item }} /bin/true'
         state=present
-    when: cis_conf_file.stat.exists
+        create=True
     with_items:
         - dccp
         - sctp


### PR DESCRIPTION
This pull request refactors section 7.5.0 and adds a new preparation task to create /etc/modprobe.d/ if it doesn't exist.

This fixes an error with Ubuntu 16.04 (tested in a Docker container) where this directory doesn't exist by default.
