### PR TITLE
Fix warnings concerning deprecated use of bare variables

### DIFF
--- a/tasks/section_02_level1.yml
+++ b/tasks/section_02_level1.yml
@@ -115,7 +115,7 @@
     file:
         path: "{{ item }}"
         mode: "a+t"
-    with_items: sticky_bit_dirs.stdout_lines
+    with_items: "{{sticky_bit_dirs.stdout_lines}}"
     tags:
       - section2
       - section2.17

--- a/tasks/section_08_level1.yml
+++ b/tasks/section_08_level1.yml
@@ -80,7 +80,7 @@
 
   - name: 8.2.4.2 Create and Set Permissions on rsyslog Log Files (Scored)
     shell: 'mkdir -p -- "$(dirname -- {{ item }})"; touch -- {{ item }}' 
-    with_items: result.stdout_lines          
+    with_items: "{{result.stdout_lines}}"
     changed_when: False
     register: rsyslog_files_created
     tags:
@@ -95,7 +95,7 @@
         group: "{{ rsyslog_log_files_group }}"
         mode: "{{ rsyslog_log_files_permissions }}"
     when: "(rsyslog_files_created.results|length > 0) and ('skipped' not in rsyslog_files_created.results[0])"
-    with_items: result.stdout_lines
+    with_items: "{{result.stdout_lines}}"
     notify: restart rsyslog
     tags:
       - section8

--- a/tasks/section_10_level1.yml
+++ b/tasks/section_10_level1.yml
@@ -41,7 +41,7 @@
 
   - name: 10.2 Disable System Accounts (Scored)
     command: /usr/sbin/usermod -s /usr/sbin/nologin {{ item }}
-    with_items: awk_etc_passwd.stdout_lines
+    with_items: "{{awk_etc_passwd.stdout_lines}}"
     tags:
       - section10
       - section10.2

--- a/tasks/section_12_level1.yml
+++ b/tasks/section_12_level1.yml
@@ -47,8 +47,7 @@
 
   - name: 12.7 Find World Writable Files (Not Scored)
     debug: msg="{{ item }}"
-    with_items:
-        world_files.stdout_lines
+    with_items: "{{world_files.stdout_lines}}"
     tags:
       - section12
       - section12.7
@@ -64,8 +63,7 @@
 
   - name: 12.8 Find Un-owned Files and Directories (Scored)
     debug: msg="{{ item }}"
-    with_items:
-        unowned_files.stdout_lines
+    with_items: "{{unowned_files.stdout_lines}}"
     tags:
       - section12
       - section12.9
@@ -82,8 +80,7 @@
   - name: 12.9 Find Un-grouped Files and Directories (Scored)
     debug: >
         msg="{{ item }}"
-    with_items:
-        ungrouped_files.stdout_lines
+    with_items: "{{ungrouped_files.stdout_lines}}"
     tags:
       - section12
       - section12.9
@@ -99,8 +96,7 @@
 
   - name: 12.10 Find SUID System Executables (Not Scored)
     debug: msg="{{ item }}"
-    with_items:
-        suid_files.stdout_lines
+    with_items: "{{suid_files.stdout_lines}}"
     tags:
       - section12
       - section12.10
@@ -116,8 +112,7 @@
 
   - name: 12.11 Find SGID System Executables (Not Scored)
     debug: msg="{{ item }}"
-    with_items:
-        gsuid_files.stdout_lines
+    with_items: "{{gsuid_files.stdout_lines}}"
     tags:
       - section12
       - section12.10

--- a/tasks/section_13_level1.yml
+++ b/tasks/section_13_level1.yml
@@ -11,8 +11,7 @@
 
   - name: 13.1 Ensure Password Fields are Not Empty (locking accounts) (Scored)
     command: passwd -l '{{ item }}'
-    with_items:
-        awk_empty_shadow.stdout_lines
+    with_items: "{{awk_empty_shadow.stdout_lines}}"
     when: lock_shadow_accounts == True
     tags:
       - section13
@@ -89,8 +88,7 @@
         state=directory
         owner=root
         mode='o-w,g-w'
-    with_items:
-        dot_in_path.stdout_lines
+    with_items: "{{dot_in_path.stdout_lines}}"
     tags:
       - section13
       - section13.6
@@ -109,8 +107,7 @@
         path='{{ item }}'
         mode='g-w,o-rwx'
         state=directory
-    with_items:
-        home_users.stdout_lines
+    with_items: "{{home_users.stdout_lines}}"
     when: modify_user_homes == True
     tags:
       - section13
@@ -131,8 +128,7 @@
         path='{{ item }}'
         follow=yes
         mode='o-w,g-w'
-    with_items:
-        home_dot_files.stdout_lines
+    with_items: "{{home_dot_files.stdout_lines}}"
     tags:
       - section13
       - section13.8
@@ -143,8 +139,7 @@
         mode='g-rwx,o-rwx'
         recurse=yes
         state=directory
-    with_items:
-        home_users.stdout_lines
+    with_items: "{{home_users.stdout_lines}}"
     tags:
       - section13
       - section13.9
@@ -153,8 +148,7 @@
     file: >
         state=absent
         path='{{ item }}/.rhosts'
-    with_items:
-        home_users.stdout_lines
+    with_items: "{{home_users.stdout_lines}}"
     tags:
       - section13
       - section13.10
@@ -170,8 +164,7 @@
 
   - name: 13.11 Check Groups in /etc/passwd (Scored)
     command: grep -q -P "^.*?:[^:]*:{{ item }}:" /etc/group
-    with_items:
-        groups_id_cut.stdout_lines
+    with_items: "{{groups_id_cut.stdout_lines}}"
     register: groups_present
     changed_when: False
     always_run: True
@@ -181,8 +174,7 @@
 
   - name: 13.12 Check That Users Are Assigned Valid Home Directories (Scored)
     stat: path='{{ item }}'
-    with_items:
-        home_users.stdout_lines
+    with_items: "{{home_users.stdout_lines}}"
     register: rstat
     failed_when: rstat is defined and rstat.stat.isdir == False
     always_run: True
@@ -256,8 +248,7 @@
     file: >
         path='{{ item }}/.forward'
         state=absent
-    with_items:
-        home_users.stdout_lines
+    with_items: "{{home_users.stdout_lines}}"
     tags:
       - section13
       - section13.19
@@ -287,8 +278,7 @@
   - name: 13.20.2 Ensure shadow group is empty (Scored)
     shell: awk -F':' '($4 == "{{ item }}") { print }' /etc/passwd
     register: awk_passwd_shadow
-    with_items:
-        shadow_group_id.stdout_lines
+    with_items: "{{shadow_group_id.stdout_lines}}"
     changed_when: False
     failed_when: awk_passwd_shadow.stdout != ''
     always_run: True


### PR DESCRIPTION
Using bare variable in `with_items` results in the following with the last version of Ansible (`2.0.2.0-1`):

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks
 so that the environment value uses the full variable syntax ('{{some_var}}').
This feature will be removed in a future release. Deprecation warnings can be
disabled by setting deprecation_warnings=False in ansible.cfg.
```
