### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ADD . /cis-ubuntu-ansible
 WORKDIR /cis-ubuntu-ansible
 
 RUN apt-get update
-RUN apt-get -y install python-pip aptitude rsh-client rsh-redone-client talk avahi-daemon cups isc-dhcp-server ntp rpcbind nfs-kernel-server bind9 openssh-client openssh-server python-dev slapd nis
-RUN pip install ansible
+RUN apt-get -y install python-pip aptitude rsh-client rsh-redone-client talk avahi-daemon cups isc-dhcp-server ntp rpcbind nfs-kernel-server bind9 openssh-client openssh-server python-dev slapd nis libffi-dev libssl-dev
+RUN pip install --upgrade setuptools ansible
 RUN touch /etc/inetd.conf
 RUN echo 'shell.bla' > /tmp/inetd
 RUN cp /tmp/inetd /etc/inetd.conf
@@ -38,7 +38,7 @@ ADD . /cis-ubuntu-ansible
 WORKDIR /cis-ubuntu-ansible
 
 RUN apt-get update
-RUN apt-get -y install python-pip aptitude rsh-client rsh-redone-client talk avahi-daemon cups isc-dhcp-server ntp rpcbind nfs-kernel-server bind9 openssh-client openssh-server python-dev slapd nis sudo
+RUN apt-get -y install python-pip aptitude rsh-client rsh-redone-client talk avahi-daemon cups isc-dhcp-server ntp rpcbind nfs-kernel-server bind9 openssh-client openssh-server python-dev slapd nis sudo libffi-dev
 RUN pip install ansible
 RUN touch /etc/inetd.conf
 RUN echo 'shell.bla' > /tmp/inetd
@@ -69,9 +69,9 @@ ADD . /cis-ubuntu-ansible
 WORKDIR /cis-ubuntu-ansible
 
 RUN apt-get update
-RUN apt-get -y install python-pip aptitude rsh-client rsh-redone-client talk avahi-daemon cups isc-dhcp-server ntp rpcbind nfs-kernel-server bind9 openssh-client openssh-server python-dev sudo
+RUN apt-get -y install python-pip aptitude rsh-client rsh-redone-client talk avahi-daemon cups isc-dhcp-server ntp rpcbind nfs-kernel-server bind9 openssh-client openssh-server python-dev sudo libffi-dev libssl-dev
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y install slapd nis
-RUN pip install ansible
+RUN pip install --upgrade setuptools ansible
 RUN touch /etc/inetd.conf
 RUN echo 'shell.bla' > /tmp/inetd
 RUN cp /tmp/inetd /etc/inetd.conf
@@ -101,7 +101,8 @@ ADD . /cis-ubuntu-ansible
 WORKDIR /cis-ubuntu-ansible
 
 RUN apt-get update
-RUN apt-get -y install python-pip aptitude rsh-client rsh-redone-client talk avahi-daemon cups isc-dhcp-server ntp rpcbind nfs-kernel-server bind9 openssh-client openssh-server python-dev slapd nis
+RUN apt-get -y install python-pip aptitude rsh-client rsh-redone-client talk avahi-daemon cups isc-dhcp-server ntp rpcbind nfs-kernel-server bind9 openssh-client openssh-server python-dev libffi-dev libssl-dev
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install slapd nis
 RUN pip install ansible
 RUN touch /etc/inetd.conf
 RUN echo 'shell.bla' > /tmp/inetd

--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN cat results_indempotence.txt | grep -q 'changed=0.*failed=0' && (echo 'Idemp
 
 
 
-FROM ubuntu:14.10
+FROM ubuntu:16.04
 MAINTAINER Paul Chaignon <paul.chaignon@gmail.com>
 
 ADD . /cis-ubuntu-ansible


### PR DESCRIPTION
This pull request fixes the Dockerfile, which contains tests for several Linux distributions. It also replaces Ubuntu 14.10 by Ubuntu 16.04. 

Our Docker build [has been failing for some time now](https://hub.docker.com/r/awailly/cis-ubuntu-ansible/builds/). Unfortunately, this build is not very useful (even though it runs limited tests on more Linux distributions than any other CI) since we do not receive automatic notifications when it fails. It may not be too long to build an IRC notification system from the webhook feature they offer...
