### PR TITLE
Completely drop support for Ansible 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Prerequisites
 
-The role is focused on hardening an Ubuntu 14.04 system. However it has been successfully tested on other Debian based systems (Debian 8, Raspbian). The minimum requirements of the targeted system are `ssh`, `aptitude` and `python2`.
+The role is focused on hardening an Ubuntu 14.04 system. However it has been successfully tested on other Debian based systems (Debian 8, Raspbian). The minimum requirements of the targeted system are `ssh`, `aptitude` and `python2`; `ansible>=1.9` is required on your local system.
 
 ## Usage
 

--- a/tasks/check_requirements.yml
+++ b/tasks/check_requirements.yml
@@ -3,7 +3,3 @@
   - name: Check if OS is Debian-based (we do not support others)
     debug: msg="Check OS family"
     failed_when: ansible_os_family != "Debian"
-
-  - name: Check if Ansible version is supported
-    debug: msg="Check Ansible version"
-    failed_when: ansible_version.full | version_compare('1.8', '<')


### PR DESCRIPTION
This pull request completely drops support for Ansible 1.8 (remove the check in requirements). The syntax is not compatible with Ansible 1.8 anyway.

Fixes #98 (by avoiding using the faulty line).
