### PR TITLE
Fix #101 errors with undefined variable

### DIFF
--- a/tasks/section_02_level1.yml
+++ b/tasks/section_02_level1.yml
@@ -109,7 +109,6 @@
     tags:
       - section2
       - section2.17
-      - section2.17.1
 
   - name: 2.17.2 Set Sticky Bit on All World-Writable Directories (Scored)
     file:
@@ -119,7 +118,6 @@
     tags:
       - section2
       - section2.17
-      - section2.17.2
 
   - name: 2.25 Disable Automounting (stat) (Scored)
     stat: >

--- a/tasks/section_02_level1.yml
+++ b/tasks/section_02_level1.yml
@@ -100,7 +100,7 @@
       - section2.15
       - section2.16
 
-  - name: 2.17.1 Set Sticky Bit on All World-Writable Directories (preparation) (Scored)
+  - name: 2.17.1 Set Sticky Bit on All World-Writable Directories (check) (Scored)
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 -print 2>/dev/null
     failed_when: False
     changed_when: False
@@ -119,7 +119,7 @@
       - section2
       - section2.17
 
-  - name: 2.25 Disable Automounting (stat) (Scored)
+  - name: 2.25.1 Disable Automounting (check) (Scored)
     stat: >
         path=/etc/init/autofs.conf
     register: autofs_file
@@ -127,7 +127,7 @@
       - section2
       - section2.25
       
-  - name: 2.25 Disable Automounting (Scored)
+  - name: 2.25.2 Disable Automounting (Scored)
     lineinfile: >
         dest=/etc/init/autofs.conf
         line='#start on runlevel [2345]'

--- a/tasks/section_04_level1.yml
+++ b/tasks/section_04_level1.yml
@@ -78,21 +78,21 @@
       - section4
       - section4.3
 
-  - name: 4.4 Disable Prelink (check) (Scored)
+  - name: 4.4.1 Disable Prelink (check) (Scored)
     stat: path=/usr/sbin/prelink
     register: prelink_rc
     tags:
       - section4
       - section4.4
 
-  - name: 4.4 Disable Prelink (restore) (Scored)
+  - name: 4.4.2 Disable Prelink (restore) (Scored)
     command: '/usr/sbin/prelink -ua'
     when: prelink_rc.stat.exists == True
     tags:
       - section4
       - section4.4
 
-  - name: 4.4 Disable Prelink (remove) (Scored)
+  - name: 4.4.3 Disable Prelink (remove) (Scored)
     apt: purge=yes name='prelink' state=absent
     when: prelink_rc.stat.exists == True
     tags:

--- a/tasks/section_04_level2.yml
+++ b/tasks/section_04_level2.yml
@@ -3,6 +3,9 @@
   - name: Check if the grub config file exists (Not Scored)
     stat: path=/etc/default/grub
     register: grub_cfg_file
+    tags:
+      - section4
+      - section4.5
 
   - name: Determines if apparmor is set in grub config (Not Scored)
     command: "grep 'GRUB_CMDLINE_LINUX' /etc/default/grub"
@@ -10,10 +13,16 @@
     changed_when: False
     when: grub_cfg_file.stat.exists
     always_run: True
+    tags:
+      - section4
+      - section4.5
 
   - name: Check if the extlinux config file exists (Not Scored)
     stat: path=/extlinux.conf
     register: extlinux_cfg_file
+    tags:
+      - section4
+      - section4.5
 
   - name: Determines if apparmor is set in extlinux (Not Scored)
     command: "grep 'apparmor' /extlinux.conf"
@@ -21,12 +30,18 @@
     changed_when: False
     when: extlinux_cfg_file.stat.exists
     always_run: True
+    tags:
+      - section4
+      - section4.5
 
   - name: Determines if apparmor is already set in boot config (Not Scored)
     command: "grep CONFIG_DEFAULT_SECURITY_APPARMOR /boot/config-{{ ansible_kernel }}"
     register: boot_apparmor
     changed_when: False
     always_run: True
+    tags:
+      - section4
+      - section4.5
 
   - name: 4.5 Activate AppArmor (install) (Scored)
     apt: >

--- a/tasks/section_04_level2.yml
+++ b/tasks/section_04_level2.yml
@@ -1,13 +1,13 @@
 ---
 
-  - name: Check if the grub config file exists (Not Scored)
+  - name: 4.5.1 Check if the grub config file exists (Not Scored)
     stat: path=/etc/default/grub
     register: grub_cfg_file
     tags:
       - section4
       - section4.5
 
-  - name: Determines if apparmor is set in grub config (Not Scored)
+  - name: 4.5.2 Determines if AppArmor is set in grub config (Not Scored)
     command: "grep 'GRUB_CMDLINE_LINUX' /etc/default/grub"
     register: grub_apparmor
     changed_when: False
@@ -17,14 +17,14 @@
       - section4
       - section4.5
 
-  - name: Check if the extlinux config file exists (Not Scored)
+  - name: 4.5.3 Check if the extlinux config file exists (Not Scored)
     stat: path=/extlinux.conf
     register: extlinux_cfg_file
     tags:
       - section4
       - section4.5
 
-  - name: Determines if apparmor is set in extlinux (Not Scored)
+  - name: 4.5.4 Determines if AppArmor is set in extlinux (Not Scored)
     command: "grep 'apparmor' /extlinux.conf"
     register: extlinux_apparmor
     changed_when: False
@@ -34,7 +34,7 @@
       - section4
       - section4.5
 
-  - name: Determines if apparmor is already set in boot config (Not Scored)
+  - name: 4.5.5 Determines if AppArmor is already set in boot config (Not Scored)
     command: "grep CONFIG_DEFAULT_SECURITY_APPARMOR /boot/config-{{ ansible_kernel }}"
     register: boot_apparmor
     changed_when: False
@@ -43,7 +43,7 @@
       - section4
       - section4.5
 
-  - name: 4.5 Activate AppArmor (install) (Scored)
+  - name: 4.5.6 Activate AppArmor (install) (Scored)
     apt: >
         name=apparmor
         state=present
@@ -52,7 +52,7 @@
       - section4
       - section4.5
 
-  - name: 4.5 Activate AppArmor (Kernel LSM - grub) (Scored)
+  - name: 4.5.7 Activate AppArmor (Kernel LSM - grub) (Scored)
     lineinfile: >
         dest='/etc/default/grub'
         regexp='^GRUB_CMDLINE_LINUX=""'
@@ -63,7 +63,7 @@
       - section4
       - section4.5
 
-  - name: 4.5 Activate AppArmor (Kernel LSM - extlinux) (Scored)
+  - name: 4.5.8 Activate AppArmor (Kernel LSM - extlinux) (Scored)
     lineinfile: >
         dest='/extlinux.conf'
         regexp="^append initrd="
@@ -73,7 +73,7 @@
       - section4
       - section4.5
 
-  - name: 4.5 Activate AppArmor (start) (Scored)
+  - name: 4.5.9 Activate AppArmor (start) (Scored)
     service: >
         name=apparmor
         state=started
@@ -84,11 +84,11 @@
       - section4
       - section4.5
 
-  - name: 4.5 Determine if Apparmor started without error (Not Scored)
+  - name: 4.5.10 Determine if AppArmor started without error (Not Scored)
     fail: msg="Apparmor can not be started. This is normal behavior if you run the playbook for the first time.\nPlease reboot the machine and run it again to proceed with the rest of the playbook."
     when: apparmor_status.failed is defined
 
-  - name: 4.5 Fix rsyslog /run/utmp permissions (Not Scored)
+  - name: 4.5.11 Fix rsyslog /run/utmp permissions (Not Scored)
     lineinfile: >
         dest="/etc/apparmor.d/usr.sbin.rsyslogd"
         line="  /run/utmp rk,"
@@ -99,7 +99,7 @@
       - section4
       - section4.5
 
-  - name: 4.5 Activate AppArmor (fix profiles) (Scored)
+  - name: 4.5.12 Activate AppArmor (fix profiles) (Scored)
     service: >
         name=rsyslog
         state=restarted
@@ -109,7 +109,7 @@
       - section4
       - section4.5
 
-  - name: 4.5 Activate AppArmor (Scored)
+  - name: 4.5.13 Activate AppArmor (Scored)
     command: apparmor_status
     register: aa_status_lines
     failed_when: '"0 profiles are loaded" in aa_status_lines.stdout_lines or "0 processes are in complain mode." not in aa_status_lines.stdout_lines or "0 processes are unconfined but have a profile defined." not in aa_status_lines.stdout_lines'
@@ -120,7 +120,7 @@
       - section4
       - section4.5
 
-  - name: 4.5 Activate AppArmor (enforce install) (Scored)
+  - name: 4.5.14 Activate AppArmor (enforce install) (Scored)
     apt: >
         name=apparmor-utils
         state=present
@@ -129,7 +129,7 @@
       - section4
       - section4.5
 
-  - name: 4.5 Activate AppArmor (enforce) (Scored)
+  - name: 4.5.15 Activate AppArmor (enforce) (Scored)
     #shell: 'aa-enforce /etc/apparmor.d/*'
     shell: for profile in /etc/apparmor.d/*; do aa-enforce $profile; done
     register: aaenforce_rc

--- a/tasks/section_05_level1.yml
+++ b/tasks/section_05_level1.yml
@@ -47,7 +47,6 @@
     - section5
     - section5.1
     - section5.1.3
-    - section5.1.3.1
 
   - name: 5.1.3.2 Ensure rsh client is not installed (Scored)
     apt: name=rsh-redone-client state=absent purge=yes
@@ -55,7 +54,6 @@
     - section5
     - section5.1
     - section5.1.3
-    - section5.1.3.2
 
   - name: 5.1.5 Ensure talk client is not installed (Scored)
     apt: name=talk state=absent purge=yes

--- a/tasks/section_05_level1.yml
+++ b/tasks/section_05_level1.yml
@@ -7,7 +7,7 @@
     - section5.1
     - section5.1.1
 
-  - name: 5.1.2 Ensure rsh, rlogin, rexec, talk, telnet, chargen, daytime, echo, discard, time is not enabled (stat inetd) (Scored)
+  - name: 5.1.2.1 Ensure rsh, rlogin, rexec, talk, telnet, chargen, daytime, echo, discard, time is not enabled (stat inetd) (Scored)
     stat: path=/etc/inetd.conf
     register: inetd_path
     tags:
@@ -15,7 +15,7 @@
     - section5.1
     - section5.1.2
 
-  - name: 5.1.2-.6 Ensure rsh, rlogin, rexec, talk, telnet, chargen, daytime, echo, discard, time is not enabled (Scored)
+  - name: 5.1.2.2 Ensure rsh, rlogin, rexec, talk, telnet, chargen, daytime, echo, discard, time is not enabled (Scored)
     lineinfile: >
         dest=/etc/inetd.conf
         regexp='^({{ item }}.*)'
@@ -62,7 +62,7 @@
     - section5.1
     - section5.1.5
 
-  - name: 5.1.8 Ensure xinetd is not enabled (stat xinetd) (Scored)
+  - name: 5.1.8.1 Ensure xinetd is not enabled (stat xinetd) (Scored)
     stat: path=/etc/init/xinetd.conf
     register: xinetd_path
     tags:
@@ -70,7 +70,7 @@
     - section5.1
     - section5.1.8
 
-  - name: 5.1.8 Ensure xinetd is not enabled (Scored)
+  - name: 5.1.8.2 Ensure xinetd is not enabled (Scored)
     lineinfile: >
         dest=/etc/init/xinetd.conf
         regexp='start on runlevel'

--- a/tasks/section_06_level1.yml
+++ b/tasks/section_06_level1.yml
@@ -7,14 +7,14 @@
       - section6
       - section6.1
 
-  - name: 6.2 Ensure Avahi Server is not enabled (check) (Scored)
+  - name: 6.2.1 Ensure Avahi Server is not enabled (check) (Scored)
     stat: path='/etc/init/avahi-daemon.conf'
     register: avahi_stat
     tags:
       - section6
       - section6.2
 
-  - name: 6.2 Ensure Avahi Server is not enabled (Scored)
+  - name: 6.2.2 Ensure Avahi Server is not enabled (Scored)
     lineinfile: >
         line='#start on (filesystem'
         state=present
@@ -25,14 +25,14 @@
       - section6
       - section6.2
 
-  - name: 6.3 Ensure print server is not enabled (check) (Not Scored)
+  - name: 6.3.1 Ensure print server is not enabled (check) (Not Scored)
     stat: path='/etc/init/cups.conf'
     register: cups_stat
     tags:
       - section6
       - section6.3
 
-  - name: 6.3 Ensure print server is not enabled (Not Scored)
+  - name: 6.3.2 Ensure print server is not enabled (Not Scored)
     lineinfile: >
         line='#start on (filesystem'
         state=present
@@ -43,7 +43,7 @@
       - section6
       - section6.3
 
-  - name: 6.4.1 Ensure DHCP Server is not enabled (check) (Scored)
+  - name: 6.4.1.1 Ensure DHCP Server is not enabled (check) (Scored)
     stat: path='/etc/init/isc-dhcp-server.conf'
     register: dhcp_stat
     tags:
@@ -51,7 +51,7 @@
       - section6.4
       - section6.4.1
 
-  - name: 6.4.1 Ensure DHCP Server is not enabled (Scored)
+  - name: 6.4.1.2 Ensure DHCP Server is not enabled (Scored)
     lineinfile: >
         line='#start on runlevel [2345]'
         state=present
@@ -63,7 +63,7 @@
       - section6.4
       - section6.4.1
 
-  - name: 6.4.2 Ensure DHCP Server is not enabled (check) (Scored)
+  - name: 6.4.2.1 Ensure DHCP Server is not enabled (check) (Scored)
     stat: path='/etc/init/isc-dhcp-server6.conf'
     register: dhcp6_stat
     tags:
@@ -71,7 +71,7 @@
       - section6.4
       - section6.4.2
 
-  - name: 6.4.2 Ensure DHCP Server is not enabled (Scored)
+  - name: 6.4.2.2 Ensure DHCP Server is not enabled (Scored)
     lineinfile: >
         line='#start on runlevel [2345]'
         state=present
@@ -83,14 +83,14 @@
       - section6.4
       - section6.4.2
 
-  - name: 6.5.1 Configure Network Time Protocol (install) (NTP) (Scored)
+  - name: 6.5.1.1 Configure Network Time Protocol (install) (NTP) (Scored)
     apt: name=ntp state=present
     tags:
       - section6
       - section6.5
       - section6.5.1
 
-  - name: 6.5.1 Check if /etc/ntp.conf file exists (stat)
+  - name: 6.5.1.2 Check if /etc/ntp.conf file exists (stat)
     stat:
         path: /etc/ntp.conf
     register: ntp_conf_file
@@ -116,7 +116,7 @@
       - section6.7
       - section6.7.1
 
-  - name: 6.7.2 Ensure NFS and RPC are not enabled (Not Scored)
+  - name: 6.7.2.1 Ensure NFS and RPC are not enabled (Not Scored)
     lineinfile: >
         dest=/etc/init/rpcbind-boot.conf
         line='#start on virtual-filesystems and net-device-up IFACE=lo'
@@ -128,7 +128,7 @@
       - section6.7
       - section6.7.2
 
-  - name: 6.7.2 Ensure NFS and RPC are not enabled (check) (Not Scored)
+  - name: 6.7.2.2 Ensure NFS and RPC are not enabled (check) (Not Scored)
     command: dpkg -S nfs-kernel-server
     changed_when: False
     failed_when: False
@@ -139,7 +139,7 @@
       - section6.7
       - section6.7.2
 
-  - name: 6.7.2 Ensure NFS and RPC are not enabled (rc.d) (Not Scored)
+  - name: 6.7.2.3 Ensure NFS and RPC are not enabled (rc.d) (Not Scored)
     service: >
         name=nfs-kernel-server
         enabled=no
@@ -174,14 +174,14 @@
       - section6.13
       - section6.14
 
-  - name: 6.15 Configure Mail Transfer Agent for Local-Only Mode (stat) (Scored)
+  - name: 6.15.1 Configure Mail Transfer Agent for Local-Only Mode (check) (Scored)
     stat: path=/etc/postfix/main.cf
     register: postfix_main_cf
     tags:
       - section6
       - section6.15
 
-  - name: 6.15 Configure Mail Transfer Agent for Local-Only Mode (Scored)
+  - name: 6.15.2 Configure Mail Transfer Agent for Local-Only Mode (Scored)
     lineinfile: >
         dest=/etc/postfix/main.cf
         regexp='^inet_interfaces ='
@@ -192,14 +192,14 @@
       - section6
       - section6.15
 
-  - name: 6.16 Ensure rsync service is not enabled (stat) (Scored)
+  - name: 6.16.1 Ensure rsync service is not enabled (check) (Scored)
     stat: path=/etc/default/rsync
     register: default_rsync
     tags:
       - section6
       - section6.16
 
-  - name: 6.16 Ensure rsync service is not enabled (Scored)
+  - name: 6.16.2 Ensure rsync service is not enabled (Scored)
     lineinfile: >
         dest='/etc/default/rsync'
         regexp='^RSYNC_ENABLE'

--- a/tasks/section_06_level1.yml
+++ b/tasks/section_06_level1.yml
@@ -132,6 +132,7 @@
     command: dpkg -S nfs-kernel-server
     changed_when: False
     failed_when: False
+    always_run: True
     register: nfs_present
     tags:
       - section6

--- a/tasks/section_06_level1_05.yml
+++ b/tasks/section_06_level1_05.yml
@@ -22,7 +22,7 @@
       - section6.5
       - section6.5.3
 
-  - name: 6.5.4 Configure Network Time Protocol (server check) (NTP) (Scored)
+  - name: 6.5.4.1 Configure Network Time Protocol (server check) (NTP) (Scored)
     command: 'grep "^server" /etc/ntp.conf'
     register: ntp_server_rc
     changed_when: False
@@ -33,7 +33,7 @@
       - section6.5
       - section6.5.4
 
-  - name: 6.5.4 Configure Network Time Protocol (server add) (NTP) (Scored)
+  - name: 6.5.4.2 Configure Network Time Protocol (server add) (NTP) (Scored)
     lineinfile: >
         dest='/etc/ntp.conf'
         line='server {{ ntp_server }}'

--- a/tasks/section_07_level1.yml
+++ b/tasks/section_07_level1.yml
@@ -296,7 +296,7 @@
       - section7
       - section7.6
 
-  - name: 7.7 Ensure Firewall is active (install) (Scored)
+  - name: 7.7.1 Ensure Firewall is active (install) (Scored)
     apt: >
         name=ufw
         state=present
@@ -305,7 +305,7 @@
       - section7
       - section7.7
 
-  - name: 7.7 Ensure Firewall is active (Scored)
+  - name: 7.7.2 Ensure Firewall is active (Scored)
     service: >
         name=ufw
         state=started

--- a/tasks/section_07_level1.yml
+++ b/tasks/section_07_level1.yml
@@ -19,7 +19,6 @@
       - section7
       - section7.1
       - section7.1.2
-      - section7.1.2.1
 
   - name: 7.1.2.2 Disable Send Packet Redirects (Scored)
     sysctl: >
@@ -30,7 +29,6 @@
       - section7
       - section7.1
       - section7.1.2
-      - section7.1.2.2
 
   - name: 7.2.1.1 Disable Source Routed Packet Acceptance (Scored)
     sysctl: >
@@ -41,7 +39,6 @@
       - section7
       - section7.2
       - section7.2.1
-      - section7.2.1.1
 
   - name: 7.2.1.2 Disable Source Routed Packet Acceptance (Scored)
     sysctl: >
@@ -52,7 +49,6 @@
       - section7
       - section7.2
       - section7.2.1
-      - section7.2.1.2
 
   - name: 7.2.2.1 Disable ICMP Redirect Acceptance (Scored)
     sysctl: >
@@ -63,7 +59,6 @@
       - section7
       - section7.2
       - section7.2.2
-      - section7.2.2.1
 
   - name: 7.2.2.2 Disable ICMP Redirect Acceptance (Scored)
     sysctl: >
@@ -74,7 +69,6 @@
       - section7
       - section7.2
       - section7.2.2
-      - section7.2.2.2
 
   - name: 7.2.3.1 Disable Secure ICMP Redirect Acceptance (Scored)
     sysctl: >
@@ -85,7 +79,6 @@
       - section7
       - section7.2
       - section7.2.3
-      - section7.2.3.1
 
   - name: 7.2.3.2 Disable Secure ICMP Redirect Acceptance (Scored)
     sysctl: >
@@ -96,7 +89,6 @@
       - section7
       - section7.2
       - section7.2.3
-      - section7.2.3.2
 
   - name: 7.2.4.1 Log Suspicious Packets (Scored)
     sysctl: >
@@ -107,7 +99,6 @@
       - section7
       - section7.2
       - section7.2.4
-      - section7.2.4.1
 
   - name: 7.2.4.2 Log Suspicious Packets (Scored)
     sysctl: >
@@ -118,7 +109,6 @@
       - section7
       - section7.2
       - section7.2.4
-      - section7.2.4.2
 
   - name: 7.2.5 Enable Ignore Broadcast Requests (Scored)
     sysctl: >
@@ -149,7 +139,6 @@
       - section7
       - section7.2
       - section7.2.7
-      - section7.2.7.1
 
   - name: 7.2.7.2 Enable RFC-recommended Source Route Validation (Scored)
     sysctl: >
@@ -160,7 +149,6 @@
       - section7
       - section7.2
       - section7.2.7
-      - section7.2.7.2
 
   - name: 7.2.8 Enable TCP SYN Cookies (Scored)
     sysctl: >
@@ -182,7 +170,6 @@
       - section7
       - section7.3
       - section7.3.1
-      - section7.3.1.1
 
   - name: 7.3.1.2 Disable IPv6 Router Advertisements (Not Scored)
     sysctl: >
@@ -193,7 +180,6 @@
       - section7
       - section7.3
       - section7.3.1
-      - section7.3.1.2
 
   - name: 7.3.2.1 Disable IPv6 Redirect Acceptance (Not Scored)
     sysctl: >
@@ -204,7 +190,6 @@
       - section7
       - section7.3
       - section7.3.2
-      - section7.3.2.1
 
   - name: 7.3.2.2 Disable IPv6 Redirect Acceptance (Not Scored)
     sysctl: >
@@ -215,7 +200,6 @@
       - section7
       - section7.3
       - section7.3.2
-      - section7.3.2.2
 
   - name: 7.3.3 Disable IPv6 (Not Scored)
     sysctl: >

--- a/tasks/section_08_level1.yml
+++ b/tasks/section_08_level1.yml
@@ -68,7 +68,7 @@
       - section8.2
       - section8.2.3
 
-  - name: 8.2.4.1 Create and Set Permissions on rsyslog Log Files (Scored)
+  - name: 8.2.4.1 Create and Set Permissions on rsyslog Log Files (check) (Scored)
     shell: awk '{ print $NF }' /etc/rsyslog.d/* /etc/rsyslog.conf | grep -oiP "/var/log/[\w\.-]+"
     register: result
     changed_when: False
@@ -125,7 +125,7 @@
       - section8.2
       - section8.2.5
 
-  - name: 8.2.6.1 Accept Remote rsyslog Messages Only on Designated Log Hosts (Not Scored)
+  - name: 8.2.6.1 Accept Remote rsyslog Messages Only on Designated Log Hosts (check) (Not Scored)
     command: grep '^$ModLoad imtcp' /etc/rsyslog.conf
     register: moadloadpresent
     changed_when: False

--- a/tasks/section_08_level2.yml
+++ b/tasks/section_08_level2.yml
@@ -18,6 +18,8 @@
       - section8.1
       - section8.1.1
       - section8.1.1.1
+      - section8.1.1.2
+      - section8.1.1.3
 
   - name: Create the audit directory if it does not exists (Not Scored)
     file: >
@@ -29,6 +31,8 @@
       - section8.1
       - section8.1.1
       - section8.1.1.1
+      - section8.1.1.2
+      - section8.1.1.3
 
   - name: 8.1.1-3 Configure Data Retention (Not Scored)
     lineinfile: >

--- a/tasks/section_08_level2.yml
+++ b/tasks/section_08_level2.yml
@@ -9,7 +9,7 @@
       - section8.1.2
       - section8.1.2
 
-  - name: Check if the file auditd.conf exists (Not Scored)
+  - name: 8.1.1-3.1 Check if the file auditd.conf exists (Not Scored)
     stat: >
         path=/etc/audit/auditd.conf
     register: auditd_file
@@ -21,7 +21,7 @@
       - section8.1.1.2
       - section8.1.1.3
 
-  - name: Create the audit directory if it does not exists (Not Scored)
+  - name: 8.1.1-3.2 Create the audit directory if it does not exists (Not Scored)
     file: >
         path=/etc/audit/
         state=directory
@@ -34,7 +34,7 @@
       - section8.1.1.2
       - section8.1.1.3
 
-  - name: 8.1.1-3 Configure Data Retention (Not Scored)
+  - name: 8.1.1-3.3 Configure Data Retention (Not Scored)
     lineinfile: >
         dest=/etc/audit/auditd.conf
         regexp="{{ item.rxp }}"
@@ -56,7 +56,7 @@
       - section8.1.1.2
       - section8.1.1.3
 
-  - name: 8.1.3 Enable Auditing for Processes That Start Prior to auditd (Scored)
+  - name: 8.1.3.1 Enable Auditing for Processes That Start Prior to auditd (Scored)
     stat: path=/etc/default/grub
     register: grubcfg_file
     tags:
@@ -64,7 +64,7 @@
       - section8.1
       - section8.1.3
 
-  - name: 8.1.3 Enable Auditing for Processes That Start Prior to auditd (Scored)
+  - name: 8.1.3.2 Enable Auditing for Processes That Start Prior to auditd (Scored)
     file: >
         path=/etc/default/grub
         state=touch
@@ -74,7 +74,7 @@
       - section8.1
       - section8.1.3
 
-  - name: 8.1.3 Enable Auditing for Processes That Start Prior to auditd (Scored)
+  - name: 8.1.3.3 Enable Auditing for Processes That Start Prior to auditd (Scored)
     lineinfile: >
         dest=/etc/default/grub
         line='GRUB_CMDLINE_LINUX="audit=1"'
@@ -84,7 +84,7 @@
       - section8.1
       - section8.1.3
 
-  - name: 8.1.4 Record Events That Modify Date and Time Information (Scored)
+  - name: 8.1.4.1 Record Events That Modify Date and Time Information (Scored)
     lineinfile: >
       dest=/etc/audit/audit.rules
       line='{{ item }}'
@@ -103,7 +103,7 @@
       - section8.1
       - section8.1.4
 
-  - name: 8.1.4 Record Events That Modify Date and Time Information (Scored)
+  - name: 8.1.4.2 Record Events That Modify Date and Time Information (Scored)
     lineinfile: >
       dest=/etc/audit/audit.rules
       line='{{ item }}'
@@ -156,7 +156,7 @@
       - section8.1.16
       - section8.1.17
 
-  - name: 8.1.6,10,11,13,14,17 Record Events That Modify the System's Network Environment (64b) (Scored)
+  - name: 8.1.6,10,11,13,14,17.1 Record Events That Modify the System's Network Environment (64b) (Scored)
     lineinfile: >
       dest=/etc/audit/audit.rules
       line='{{ item }}'
@@ -196,7 +196,7 @@
       - section8.1.14
       - section8.1.17
 
-  - name: 8.1.6,10,11,13,14,17 Record Events That Modify the System's Network Environment (32b) (Scored)
+  - name: 8.1.6,10,11,13,14,17.2 Record Events That Modify the System's Network Environment (32b) (Scored)
     lineinfile: >
       dest=/etc/audit/audit.rules
       line='{{ item }}'
@@ -228,7 +228,7 @@
       - section8.1.14
       - section8.1.17
 
-  - name: 8.3.1 Install AIDE (Scored)
+  - name: 8.3.1.1 Install AIDE (Scored)
     apt: name=aide state=present
     register: aide_installed
     when: use_aide == True
@@ -237,7 +237,7 @@
       - section8.3
       - section8.3.1
 
-  - name: 8.3.1 Install AIDE (init) (Scored)
+  - name: 8.3.1.2 Install AIDE (init) (Scored)
     command: aideinit
     when:
       - use_aide == True
@@ -247,7 +247,7 @@
       - section8.3
       - section8.3.1
 
-  - name: 8.3.1 Install AIDE (Scored)
+  - name: 8.3.1.3 Install AIDE (Scored)
     stat: path=/var/lib/aide/aide.db.new
     register: aide_db_path
     when:
@@ -258,7 +258,7 @@
       - section8.3
       - section8.3.1
 
-  - name: 8.3.1 Install AIDE (copy db) (Scored)
+  - name: 8.3.1.4 Install AIDE (copy db) (Scored)
     command: mv /var/lib/aide/aide.db.new /var/lib/aide/aide.db
     when:
       - use_aide == True
@@ -278,7 +278,7 @@
       - section8.3.2
 
   # We have to run the check after AIDE installation as postfix create new matched binaries
-  - name: 8.1.12 Collect Use of Privileged Commands (Scored)
+  - name: 8.1.12.1 Collect Use of Privileged Commands (Scored)
     shell: find / -xdev \( -perm -4000 -o -perm -2000 \) -type f | awk '{print "-a always,exit -F path=" $1 " -F perm=x -F auid>=500 -F auid!=4294967295 -k privileged" }'
     register: audit_lines_for_find
     changed_when: False
@@ -287,7 +287,7 @@
       - section8.1
       - section8.1.12
 
-  - name: 8.1.12 Collect Use of Privileged Commands (infos) (Scored)
+  - name: 8.1.12.2 Collect Use of Privileged Commands (infos) (Scored)
     lineinfile: >
         dest=/etc/audit/audit.rules
         line='{{ item }}'

--- a/tasks/section_09_level1.yml
+++ b/tasks/section_09_level1.yml
@@ -63,7 +63,7 @@
       - section9.1
       - section9.1.7
 
-  - name: 9.1.8 Restrict at/cron to Authorized Users (remove deny) (Scored)
+  - name: 9.1.8.1 Restrict at/cron to Authorized Users (remove deny) (Scored)
     file: path={{ item }} state=absent
     with_items:
         - /etc/cron.deny
@@ -73,7 +73,7 @@
       - section9.1
       - section9.1.8
 
-  - name: 9.1.8 Restrict at/cron to Authorized Users (create cron allow) (Scored)
+  - name: 9.1.8.2 Restrict at/cron to Authorized Users (create cron allow) (Scored)
     copy:
         dest: /etc/cron.allow
         owner: root
@@ -86,7 +86,7 @@
       - section9.1
       - section9.1.8
 
-  - name: 9.1.8 Restrict at/cron to Authorized Users (create at allow) (Scored)
+  - name: 9.1.8.3 Restrict at/cron to Authorized Users (create at allow) (Scored)
     copy:
         dest: /etc/at.allow
         owner: root
@@ -99,7 +99,7 @@
       - section9.1
       - section9.1.8
 
-  - name: 9.2.1 Set Password Creation Requirement Parameters Using pam_cracklib (install) (Scored)
+  - name: 9.2.1.1 Set Password Creation Requirement Parameters Using pam_cracklib (install) (Scored)
     apt: name=libpam-cracklib state=present
     when: use_pam_cracklib == True
     tags:
@@ -107,7 +107,7 @@
       - section9.2
       - section9.2.1
 
-  - name: 9.2.1 Set Password Creation Requirement Parameters Using pam_cracklib (Scored)
+  - name: 9.2.1.2 Set Password Creation Requirement Parameters Using pam_cracklib (Scored)
     lineinfile: >
         dest='/etc/pam.d/common-password'
         regexp="pam_cracklib.so"
@@ -157,14 +157,14 @@
   - include: section_09_level1_03.yml
     when: ssh_config_file.stat.exists == True
 
-  - name: 9.4 Restrict root Login to System Console (stat securetty) (Not Scored)
+  - name: 9.4.1 Restrict root Login to System Console (check) (Not Scored)
     stat: path=/etc/securetty
     register: securetty_file
     tags:
       - section9
       - section9.4
 
-  - name: 9.4 Restrict root Login to System Console (Not Scored)
+  - name: 9.4.2 Restrict root Login to System Console (Not Scored)
     debug: msg='*** Check /etc/securetty for console allowed for root access ***'
     when: securetty_file.stat.exists == True
     tags:

--- a/tasks/section_09_level1_03.yml
+++ b/tasks/section_09_level1_03.yml
@@ -121,6 +121,7 @@
     register: allow_rc
     failed_when: allow_rc.rc == 1
     changed_when: False
+    always_run: True
     ignore_errors: True
     tags:
       - section9
@@ -133,6 +134,7 @@
     register: allow_rc
     failed_when: allow_rc.rc == 1
     changed_when: False
+    always_run: True
     ignore_errors: True
     tags:
       - section9
@@ -145,6 +147,7 @@
     register: allow_rc
     failed_when: allow_rc.rc == 1
     changed_when: False
+    always_run: True
     ignore_errors: True
     tags:
       - section9
@@ -157,6 +160,7 @@
     register: allow_rc
     failed_when: allow_rc.rc == 1
     changed_when: False
+    always_run: True
     ignore_errors: True
     notify: restart ssh
     tags:

--- a/tasks/section_10_level1.yml
+++ b/tasks/section_10_level1.yml
@@ -1,6 +1,6 @@
 ---
 
-  - name: 10.1.1 Set Password Expiration Days (check) (Scored)
+  - name: 10.1.1.1 Set Password Expiration Days (check) (Scored)
     command: grep -oP '(?<=^PASS_MAX_DAYS\s)[0-9]+' /etc/login.defs
     register: pass_max_days
     changed_when: False
@@ -10,7 +10,7 @@
       - section10.1
       - section10.1.1
 
-  - name: 10.1.1 Set Password Expiration Days (Scored)
+  - name: 10.1.1.2 Set Password Expiration Days (Scored)
     lineinfile: >
         dest='/etc/login.defs'
         line='PASS_MAX_DAYS 90'
@@ -21,7 +21,7 @@
       - section10.1
       - section10.1.1
 
-  - name: 10.1.2 Set Password Change Minimum Number of Days (check) (Scored)
+  - name: 10.1.2.1 Set Password Change Minimum Number of Days (check) (Scored)
     command: grep -oP '(?<=^PASS_MIN_DAYS\s)[0-9]+' /etc/login.defs
     register: pass_min_days
     changed_when: False
@@ -31,7 +31,7 @@
       - section10.1
       - section10.1.2
 
-  - name: 10.1.2 Set Password Change Minimum Number of Days (Scored)
+  - name: 10.1.2.2 Set Password Change Minimum Number of Days (Scored)
     lineinfile: >
         dest='/etc/login.defs'
         line='PASS_MIN_DAYS 7'
@@ -42,7 +42,7 @@
       - section10.1
       - section10.1.2
 
-  - name: 10.1.3 Set Password Expiring Warning Days (check) (Scored)
+  - name: 10.1.3.1 Set Password Expiring Warning Days (check) (Scored)
     command: grep -oP '(?<=^PASS_WARN_AGE\s)[0-9]+' /etc/login.defs
     register: pass_warn_age
     changed_when: False
@@ -52,7 +52,7 @@
       - section10.1
       - section10.1.3
 
-  - name: 10.1.3 Set Password Expiring Warning Days (Scored)
+  - name: 10.1.3.2 Set Password Expiring Warning Days (Scored)
     lineinfile: >
         dest='/etc/login.defs'
         line='PASS_WARN_AGE 7'
@@ -63,7 +63,7 @@
       - section10.1
       - section10.1.3
 
-  - name: 10.2 Disable System Accounts (check) (Scored)
+  - name: 10.2.1.1 Disable System Accounts (check) (Scored)
     shell: awk -F':' '($1!="root" && $1!="sync" && $1!="shutdown" &&$1!="halt" && $3<500 && $7!="/usr/sbin/nologin" && $7!="/bin/false") {print $1}' /etc/passwd
     register: awk_etc_passwd
     changed_when: False
@@ -72,7 +72,7 @@
       - section10
       - section10.2
 
-  - name: 10.2 Disable System Accounts (Scored)
+  - name: 10.2.2.2 Disable System Accounts (Scored)
     command: /usr/sbin/usermod -s /usr/sbin/nologin {{ item }}
     with_items: "{{awk_etc_passwd.stdout_lines}}"
     tags:
@@ -97,7 +97,7 @@
       - section10
       - section10.4
 
-  - name: 10.5 Lock Inactive User Accounts (check) (Scored)
+  - name: 10.5.1 Lock Inactive User Accounts (check) (Scored)
     command: grep INACTIVE /etc/login.defs
     changed_when: False
     failed_when: False
@@ -107,7 +107,7 @@
       - section10
       - section10.5
         
-  - name: 10.5 Lock Inactive User Accounts (Scored)
+  - name: 10.5.2 Lock Inactive User Accounts (Scored)
     lineinfile: >
         dest=/etc/login.defs
         line='INACTIVE=35'

--- a/tasks/section_10_level1.yml
+++ b/tasks/section_10_level1.yml
@@ -67,6 +67,7 @@
     shell: awk -F':' '($1!="root" && $1!="sync" && $1!="shutdown" &&$1!="halt" && $3<500 && $7!="/usr/sbin/nologin" && $7!="/bin/false") {print $1}' /etc/passwd
     register: awk_etc_passwd
     changed_when: False
+    always_run: True
     tags:
       - section10
       - section10.2

--- a/tasks/section_11_level1.yml
+++ b/tasks/section_11_level1.yml
@@ -1,6 +1,6 @@
 ---
 
-  - name: 11.1.1 Set Warning Banner for Standard Login Services (Scored)
+  - name: 11.1 Set Warning Banner for Standard Login Services (Scored)
     lineinfile: >
         dest={{ item }}
         create=yes
@@ -17,7 +17,7 @@
       - section11
       - section11.1
 
-  - name: 11.2.1 Remove OS Information from Login Warning Banners (Scored)
+  - name: 11.2 Remove OS Information from Login Warning Banners (Scored)
     shell: egrep '(\\v|\\r|\\m|\\s)' {{ item }}
     register: egrep_os_infos
     failed_when: egrep_os_infos.rc == 0
@@ -30,7 +30,7 @@
       - section11
       - section11.2
 
-  - name: 11.3.1 Set Graphical Warning Banner (Not Scored)
+  - name: 11.3 Set Graphical Warning Banner (Not Scored)
     debug: msg="*** Set a banner for the display manager ***"
     tags:
       - section11

--- a/tasks/section_12_level1.yml
+++ b/tasks/section_12_level1.yml
@@ -40,6 +40,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002 -print
     changed_when: False
     failed_when: False
+    always_run: True
     register: world_files
     tags:
       - section12
@@ -56,6 +57,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser -ls
     changed_when: False
     failed_when: False
+    always_run: True
     register: unowned_files
     tags:
       - section12
@@ -72,6 +74,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup -ls
     changed_when: False
     failed_when: False
+    always_run: True
     register: ungrouped_files
     tags:
       - section12
@@ -89,6 +92,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -4000 -print
     changed_when: False
     failed_when: False
+    always_run: True
     register: suid_files
     tags:
       - section12
@@ -105,6 +109,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -2000 -print
     changed_when: False
     failed_when: False
+    always_run: True
     register: gsuid_files
     tags:
       - section12

--- a/tasks/section_12_level1.yml
+++ b/tasks/section_12_level1.yml
@@ -36,7 +36,7 @@
       - section12
       - section12.6
 
-  - name: 12.7 Find World Writable Files (check) (Not Scored)
+  - name: 12.7.1 Find World Writable Files (check) (Not Scored)
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002 -print
     changed_when: False
     failed_when: False
@@ -46,14 +46,14 @@
       - section12
       - section12.7
 
-  - name: 12.7 Find World Writable Files (Not Scored)
+  - name: 12.7.2 Find World Writable Files (Not Scored)
     debug: msg="{{ item }}"
     with_items: "{{world_files.stdout_lines}}"
     tags:
       - section12
       - section12.7
 
-  - name: 12.8 Find Un-owned Files and Directories (check) (Scored)
+  - name: 12.8.1 Find Un-owned Files and Directories (check) (Scored)
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser -ls
     changed_when: False
     failed_when: False
@@ -63,14 +63,14 @@
       - section12
       - section12.8
 
-  - name: 12.8 Find Un-owned Files and Directories (Scored)
+  - name: 12.8.2 Find Un-owned Files and Directories (Scored)
     debug: msg="{{ item }}"
     with_items: "{{unowned_files.stdout_lines}}"
     tags:
       - section12
       - section12.9
 
-  - name: 12.9 Find Un-grouped Files and Directories (check) (Scored)
+  - name: 12.9.1 Find Un-grouped Files and Directories (check) (Scored)
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup -ls
     changed_when: False
     failed_when: False
@@ -80,7 +80,7 @@
       - section12
       - section12.9
 
-  - name: 12.9 Find Un-grouped Files and Directories (Scored)
+  - name: 12.9.2 Find Un-grouped Files and Directories (Scored)
     debug: >
         msg="{{ item }}"
     with_items: "{{ungrouped_files.stdout_lines}}"
@@ -88,7 +88,7 @@
       - section12
       - section12.9
 
-  - name: 12.10 Find SUID System Executables (check) (Not Scored)
+  - name: 12.10.1 Find SUID System Executables (check) (Not Scored)
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -4000 -print
     changed_when: False
     failed_when: False
@@ -98,14 +98,14 @@
       - section12
       - section12.10
 
-  - name: 12.10 Find SUID System Executables (Not Scored)
+  - name: 12.10.2 Find SUID System Executables (Not Scored)
     debug: msg="{{ item }}"
     with_items: "{{suid_files.stdout_lines}}"
     tags:
       - section12
       - section12.10
 
-  - name: 12.11 Find SGID System Executables (check) (Not Scored)
+  - name: 12.11.1 Find SGID System Executables (check) (Not Scored)
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -2000 -print
     changed_when: False
     failed_when: False
@@ -115,7 +115,7 @@
       - section12
       - section12.11
 
-  - name: 12.11 Find SGID System Executables (Not Scored)
+  - name: 12.11.2 Find SGID System Executables (Not Scored)
     debug: msg="{{ item }}"
     with_items: "{{gsuid_files.stdout_lines}}"
     tags:

--- a/tasks/section_13_level1.yml
+++ b/tasks/section_13_level1.yml
@@ -4,6 +4,7 @@
     command: awk -F':' '($2 == "" ) { print $1 }' /etc/shadow
     register: awk_empty_shadow
     changed_when: False
+    always_run: True
     failed_when: awk_empty_shadow.stdout != '' and lock_shadow_accounts == False
     tags:
       - section13
@@ -57,6 +58,7 @@
     shell: 'echo $PATH | grep ::'
     register: path_colon
     changed_when: False
+    always_run: True
     failed_when: path_colon.rc == 0
     tags:
       - section13
@@ -66,6 +68,7 @@
     shell: 'echo $PATH | grep :$'
     register: path_colon_end
     changed_when: False
+    always_run: True
     failed_when: path_colon_end.rc == 0
     tags:
       - section13
@@ -76,6 +79,7 @@
     become: yes
     register: dot_in_path
     changed_when: False
+    always_run: True
     failed_when: '"." in dot_in_path.stdout_lines'
     tags:
       - section13
@@ -98,6 +102,7 @@
     register: home_users
     changed_when: False
     failed_when: False
+    always_run: True
     tags:
       - section13
       - section13.7
@@ -231,6 +236,8 @@
   - name: 13.18 Check for Presence of User .netrc Files (stat) (Scored)
     stat: path='{{ item }}/.netrc'
     with_items: '{{ home_users.stdout_lines }}'
+    always_run: True
+    changed_when: False
     register: netrc_files
     tags:
       - section13

--- a/tasks/section_13_level1.yml
+++ b/tasks/section_13_level1.yml
@@ -1,6 +1,6 @@
 ---
 
-  - name: 13.1 Ensure Password Fields are Not Empty (Scored)
+  - name: 13.1.1 Ensure Password Fields are Not Empty (check) (Scored)
     command: awk -F':' '($2 == "" ) { print $1 }' /etc/shadow
     register: awk_empty_shadow
     changed_when: False
@@ -10,7 +10,7 @@
       - section13
       - section13.1
 
-  - name: 13.1 Ensure Password Fields are Not Empty (locking accounts) (Scored)
+  - name: 13.1.2 Ensure Password Fields are Not Empty (locking accounts) (Scored)
     command: passwd -l '{{ item }}'
     with_items: "{{awk_empty_shadow.stdout_lines}}"
     when: lock_shadow_accounts == True
@@ -118,7 +118,7 @@
       - section13
       - section13.7
 
-  - name: 13.8.1 Check User Dot File Permissions (gather dotfiles) (Scored)
+  - name: 13.8.1 Check User Dot File Permissions (check) (Scored)
     shell: for pth in `/bin/egrep -v '(root|halt|sync|shutdown)' /etc/passwd | /usr/bin/awk -F':' '($7 != "/usr/sbin/nologin") { print $6 }'`; do ls -d -A -1 $pth/.* | egrep -v '[..]$'; done
     changed_when: False
     failed_when: False
@@ -158,7 +158,7 @@
       - section13
       - section13.10
 
-  - name: 13.11 Check Groups in /etc/passwd (preparation) (Scored)
+  - name: 13.11.1 Check Groups in /etc/passwd (check) (Scored)
     command: cut -s -d':' -f4 /etc/passwd
     register: groups_id_cut
     changed_when: False
@@ -167,7 +167,7 @@
       - section13
       - section13.11
 
-  - name: 13.11 Check Groups in /etc/passwd (Scored)
+  - name: 13.11.2 Check Groups in /etc/passwd (Scored)
     command: grep -q -P "^.*?:[^:]*:{{ item }}:" /etc/group
     with_items: "{{groups_id_cut.stdout_lines}}"
     register: groups_present
@@ -233,7 +233,7 @@
       - section13
       - section13.17
 
-  - name: 13.18 Check for Presence of User .netrc Files (stat) (Scored)
+  - name: 13.18.1 Check for Presence of User .netrc Files (check) (Scored)
     stat: path='{{ item }}/.netrc'
     with_items: '{{ home_users.stdout_lines }}'
     always_run: True
@@ -243,7 +243,7 @@
       - section13
       - section13.18
 
-  - name: 13.18 Check for Presence of User .netrc Files (Scored)
+  - name: 13.18.2 Check for Presence of User .netrc Files (Scored)
     debug: msg='Check if {{ item.stat.path}} is needed, and remove otherwise'
     when: item is defined and item.stat.exists == True
     with_items: '{{ netrc_files.results }}'
@@ -260,7 +260,7 @@
       - section13
       - section13.19
 
-  - name: 13.20.1 Ensure shadow group is empty (Scored)
+  - name: 13.20.1 Ensure shadow group is empty (check) (Scored)
     shell: grep '^shadow' /etc/group | cut -f4 -d':'
     register: shadow_group_empty
     failed_when: shadow_group_empty.stdout != ''
@@ -271,7 +271,7 @@
       - section13.20
       - section13.20.1
 
-  - name: 13.20.2 Ensure shadow group is empty (preparation) (Scored)
+  - name: 13.20.2 Ensure shadow group is empty (check) (Scored)
     shell: grep '^shadow' /etc/group | cut -f1 -d':'
     register: shadow_group_id
     failed_when: False
@@ -282,7 +282,7 @@
       - section13.20
       - section13.20.1
 
-  - name: 13.20.2 Ensure shadow group is empty (Scored)
+  - name: 13.20.3 Ensure shadow group is empty (check) (Scored)
     shell: awk -F':' '($4 == "{{ item }}") { print }' /etc/passwd
     register: awk_passwd_shadow
     with_items: "{{shadow_group_id.stdout_lines}}"


### PR DESCRIPTION
As discussed in #102, there are errors with undefined variables under Ansible 1.9.

When running in check mode, _check tasks_ without an `always-run` statement are not executed.
As a consequence, subsequent _main tasks_ error on undefined variables.

This pull request adds an `always_run` statement to all _check tasks_
