### PR TITLE
Fatal postfix error due to IPv6 being disabled

### DIFF
--- a/tasks/section_06_level1.yml
+++ b/tasks/section_06_level1.yml
@@ -189,7 +189,7 @@
         state=present
     with_items:
       - { regexp: '^inet_interfaces =', line: 'inet_interfaces = localhost' }
-      - { regexp: 'inet_protocols =', line: 'inet_protocols = ipv4' }
+      - { regexp: '^inet_protocols =', line: 'inet_protocols = ipv4' }
     when: postfix_main_cf.stat.exists == True
     tags:
       - section6

--- a/tasks/section_06_level1.yml
+++ b/tasks/section_06_level1.yml
@@ -184,9 +184,12 @@
   - name: 6.15.2 Configure Mail Transfer Agent for Local-Only Mode (Scored)
     lineinfile: >
         dest=/etc/postfix/main.cf
-        regexp='^inet_interfaces ='
-        line='inet_interfaces = localhost'
+        regexp='{{ item.regexp }}'
+        line='{{ item.line }}'
         state=present
+    with_items:
+      - { regexp: '^inet_interfaces =', line: 'inet_interfaces = localhost' }
+      - { regexp: 'inet_protocols =', line: 'inet_protocols = ipv4' }
     when: postfix_main_cf.stat.exists == True
     tags:
       - section6

--- a/tasks/section_06_level1.yml
+++ b/tasks/section_06_level1.yml
@@ -184,13 +184,21 @@
   - name: 6.15.2 Configure Mail Transfer Agent for Local-Only Mode (Scored)
     lineinfile: >
         dest=/etc/postfix/main.cf
-        regexp='{{ item.regexp }}'
-        line='{{ item.line }}'
+        regexp='^inet_interfaces ='
+        line='inet_interfaces = localhost'
         state=present
-    with_items:
-      - { regexp: '^inet_interfaces =', line: 'inet_interfaces = localhost' }
-      - { regexp: '^inet_protocols =', line: 'inet_protocols = ipv4' }
     when: postfix_main_cf.stat.exists == True
+    tags:
+      - section6
+      - section6.15
+
+  - name: 6.15.3 Configure Mail Transfer Agent for Local-Only Mode (Scored)
+    lineinfile: >
+        dest=/etc/postfix/main.cf
+        regexp='^inet_protocols ='
+        line='inet_protocols = ipv4'
+        state=present
+    when: postfix_main_cf.stat.exists == True and disable_ipv6 == True
     tags:
       - section6
       - section6.15


### PR DESCRIPTION
As per the CIS benchmarks, IPv6 should be disabled if it is not used which is the default behavior of this role. When running `service posfix restart`, I noticed that I was getting the following error:

```
postmulti: fatal: parameter inet_interfaces: no local interface found for ::1
```

It turns out that the `inet_protocols = all` parameter in the `/etc/postfix/main.cf` configuration file is the culprit. Burrowing from the solution at https://forums.opensuse.org/showthread.php/436441-Postfix-error-message?p=2311113#post2311113, setting `inet_protocols = ipv4` fixed the fatal error when changing the state of the postfix service.

I am an Ansible noob so I'm not sure if there is a clean way to conditionally set the parameter based on the role's `disable_ipv6` variable, but I thought I would submit a pull request to start the conversation and get some feedback.

Thanks for a great role,
Chris
