### PR TITLE
Configure Postfix after AIDE installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,14 +17,14 @@
   - include: section_05.yml
     tags: section05
 
-  - include: section_06.yml
-    tags: section06
-
   - include: section_07.yml
     tags: section07
 
   - include: section_08.yml
     tags: section08
+
+  - include: section_06.yml
+    tags: section06
 
   - include: section_09.yml
     tags: section09


### PR DESCRIPTION
This pull request moves Section 6 after Section 8 to fix #114.

Postfix might be installed during the AIDE installation in Section 8. Section 6 changes the configuration of Postfix and should therefore happen after Section 8.

/cc @cpliakas 
