### PR TITLE
fix always_run is deprecated WARNINGs

### DIFF
--- a/tasks/section_02_level1.yml
+++ b/tasks/section_02_level1.yml
@@ -109,7 +109,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 -print 2>/dev/null
     failed_when: False
     changed_when: False
-    always_run: True
+    check_mode: no
     register: sticky_bit_dirs
     tags:
       - section2
@@ -131,7 +131,7 @@
     tags:
       - section2
       - section2.25
-      
+
   - name: 2.25.2 Disable Automounting (Scored)
     lineinfile: >
         dest=/etc/init/autofs.conf

--- a/tasks/section_03_level1.yml
+++ b/tasks/section_03_level1.yml
@@ -13,7 +13,7 @@
     when: grub_cfg_file.stat.exists == True
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section3
       - section3.3
@@ -40,7 +40,7 @@
     when: grub_cfg_file.stat.exists == True
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section3
       - section3.3
@@ -87,7 +87,7 @@
     register: root_password_set
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section3
       - section3.4

--- a/tasks/section_04_level2.yml
+++ b/tasks/section_04_level2.yml
@@ -12,7 +12,7 @@
     register: grub_apparmor
     changed_when: False
     when: grub_cfg_file.stat.exists
-    always_run: True
+    check_mode: no
     tags:
       - section4
       - section4.5
@@ -29,7 +29,7 @@
     register: extlinux_apparmor
     changed_when: False
     when: extlinux_cfg_file.stat.exists
-    always_run: True
+    check_mode: no
     tags:
       - section4
       - section4.5
@@ -38,7 +38,7 @@
     command: "grep CONFIG_DEFAULT_SECURITY_APPARMOR /boot/config-{{ ansible_kernel }}"
     register: boot_apparmor
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section4
       - section4.5

--- a/tasks/section_06_level1.yml
+++ b/tasks/section_06_level1.yml
@@ -132,7 +132,7 @@
     command: dpkg -S nfs-kernel-server
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     register: nfs_present
     tags:
       - section6

--- a/tasks/section_06_level1_05.yml
+++ b/tasks/section_06_level1_05.yml
@@ -26,7 +26,7 @@
     command: 'grep "^server" /etc/ntp.conf'
     register: ntp_server_rc
     changed_when: False
-    always_run: True
+    check_mode: no
     ignore_errors: True
     tags:
       - section6

--- a/tasks/section_08.yml
+++ b/tasks/section_08.yml
@@ -4,7 +4,7 @@
     tags:
       - section08
       - level1
-       
+
 
   - include: section_08_level2.yml
     tags:

--- a/tasks/section_08_level1.yml
+++ b/tasks/section_08_level1.yml
@@ -22,7 +22,7 @@
     register: startonfilesystem
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section8
       - section8.2
@@ -72,7 +72,7 @@
     shell: awk '{ print $NF }' /etc/rsyslog.d/* /etc/rsyslog.conf | grep -oiP "/var/log/[\w\.-]+"
     register: result
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section8
       - section8.2
@@ -107,7 +107,7 @@
     register: remoteloghost 
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section8
       - section8.2
@@ -130,7 +130,7 @@
     register: moadloadpresent
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section8
       - section8.2

--- a/tasks/section_09_level1_03.yml
+++ b/tasks/section_09_level1_03.yml
@@ -121,7 +121,7 @@
     register: allow_rc
     failed_when: allow_rc.rc == 1
     changed_when: False
-    always_run: True
+    check_mode: no
     ignore_errors: True
     tags:
       - section9
@@ -134,7 +134,7 @@
     register: allow_rc
     failed_when: allow_rc.rc == 1
     changed_when: False
-    always_run: True
+    check_mode: no
     ignore_errors: True
     tags:
       - section9
@@ -147,7 +147,7 @@
     register: allow_rc
     failed_when: allow_rc.rc == 1
     changed_when: False
-    always_run: True
+    check_mode: no
     ignore_errors: True
     tags:
       - section9
@@ -160,7 +160,7 @@
     register: allow_rc
     failed_when: allow_rc.rc == 1
     changed_when: False
-    always_run: True
+    check_mode: no
     ignore_errors: True
     notify: restart ssh
     tags:

--- a/tasks/section_10_level1.yml
+++ b/tasks/section_10_level1.yml
@@ -4,7 +4,7 @@
     command: grep -oP '(?<=^PASS_MAX_DAYS\s)[0-9]+' /etc/login.defs
     register: pass_max_days
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section10
       - section10.1
@@ -25,7 +25,7 @@
     command: grep -oP '(?<=^PASS_MIN_DAYS\s)[0-9]+' /etc/login.defs
     register: pass_min_days
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section10
       - section10.1
@@ -46,7 +46,7 @@
     command: grep -oP '(?<=^PASS_WARN_AGE\s)[0-9]+' /etc/login.defs
     register: pass_warn_age
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section10
       - section10.1
@@ -67,7 +67,7 @@
     shell: awk -F':' '($1!="root" && $1!="sync" && $1!="shutdown" &&$1!="halt" && $3<500 && $7!="/usr/sbin/nologin" && $7!="/bin/false") {print $1}' /etc/passwd
     register: awk_etc_passwd
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section10
       - section10.2
@@ -101,12 +101,12 @@
     command: grep INACTIVE /etc/login.defs
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     register: lock_inactive_rc
     tags:
       - section10
       - section10.5
-        
+
   - name: 10.5.2 Lock Inactive User Accounts (Scored)
     lineinfile: >
         dest=/etc/login.defs

--- a/tasks/section_12_level1.yml
+++ b/tasks/section_12_level1.yml
@@ -40,7 +40,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002 -print
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     register: world_files
     tags:
       - section12
@@ -57,7 +57,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser -ls
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     register: unowned_files
     tags:
       - section12
@@ -74,7 +74,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup -ls
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     register: ungrouped_files
     tags:
       - section12
@@ -92,7 +92,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -4000 -print
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     register: suid_files
     tags:
       - section12
@@ -109,7 +109,7 @@
     shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -2000 -print
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     register: gsuid_files
     tags:
       - section12

--- a/tasks/section_13_level1.yml
+++ b/tasks/section_13_level1.yml
@@ -4,7 +4,7 @@
     command: awk -F':' '($2 == "" ) { print $1 }' /etc/shadow
     register: awk_empty_shadow
     changed_when: False
-    always_run: True
+    check_mode: no
     failed_when: awk_empty_shadow.stdout != '' and lock_shadow_accounts == False
     tags:
       - section13
@@ -58,7 +58,7 @@
     shell: 'echo $PATH | grep ::'
     register: path_colon
     changed_when: False
-    always_run: True
+    check_mode: no
     failed_when: path_colon.rc == 0
     tags:
       - section13
@@ -68,7 +68,7 @@
     shell: 'echo $PATH | grep :$'
     register: path_colon_end
     changed_when: False
-    always_run: True
+    check_mode: no
     failed_when: path_colon_end.rc == 0
     tags:
       - section13
@@ -79,7 +79,7 @@
     become: yes
     register: dot_in_path
     changed_when: False
-    always_run: True
+    check_mode: no
     failed_when: '"." in dot_in_path.stdout_lines'
     tags:
       - section13
@@ -102,7 +102,7 @@
     register: home_users
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.7
@@ -122,7 +122,7 @@
     shell: for pth in `/bin/egrep -v '(root|halt|sync|shutdown)' /etc/passwd | /usr/bin/awk -F':' '($7 != "/usr/sbin/nologin") { print $6 }'`; do ls -d -A -1 $pth/.* | egrep -v '[..]$'; done
     changed_when: False
     failed_when: False
-    always_run: True
+    check_mode: no
     register: home_dot_files
     tags:
       - section13
@@ -162,7 +162,7 @@
     command: cut -s -d':' -f4 /etc/passwd
     register: groups_id_cut
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.11
@@ -172,7 +172,7 @@
     with_items: "{{groups_id_cut.stdout_lines}}"
     register: groups_present
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.11
@@ -182,7 +182,7 @@
     with_items: "{{home_users.stdout_lines}}"
     register: rstat
     failed_when: rstat is defined and rstat.stat.isdir == False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.12
@@ -198,7 +198,7 @@
     register: uids_list
     failed_when: uids_list.stdout != ''
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.14
@@ -208,7 +208,7 @@
     register: gids_list
     failed_when: gids_list.stdout != ''
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.15
@@ -218,7 +218,7 @@
     register: uids_list
     failed_when: uids_list.stdout != ''
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.16
@@ -228,7 +228,7 @@
     register: uids_list
     failed_when: uids_list.stdout != ''
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.17
@@ -236,7 +236,7 @@
   - name: 13.18.1 Check for Presence of User .netrc Files (check) (Scored)
     stat: path='{{ item }}/.netrc'
     with_items: '{{ home_users.stdout_lines }}'
-    always_run: True
+    check_mode: no
     changed_when: False
     register: netrc_files
     tags:
@@ -265,7 +265,7 @@
     register: shadow_group_empty
     failed_when: shadow_group_empty.stdout != ''
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.20
@@ -276,7 +276,7 @@
     register: shadow_group_id
     failed_when: False
     changed_when: False
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.20
@@ -288,7 +288,7 @@
     with_items: "{{shadow_group_id.stdout_lines}}"
     changed_when: False
     failed_when: awk_passwd_shadow.stdout != ''
-    always_run: True
+    check_mode: no
     tags:
       - section13
       - section13.20


### PR DESCRIPTION
This patch fixes many instances of this [DEPRECATION WARNING]: always_run is deprecated. Use check_mode = no instead..