### PR TITLE
Fix 8.1.3.3

### DIFF
--- a/tasks/section_08_level2.yml
+++ b/tasks/section_08_level2.yml
@@ -77,8 +77,10 @@
   - name: 8.1.3.3 Enable Auditing for Processes That Start Prior to auditd (Scored)
     lineinfile: >
         dest=/etc/default/grub
+        regexp='GRUB_CMDLINE_LINUX="'
         line='GRUB_CMDLINE_LINUX="audit=1"'
-    when: not grubcfg_file.stat.exists
+        state=present
+        create=yes
     tags:
       - section8
       - section8.1


### PR DESCRIPTION
GRUB_CMDLINE_LINUX="audit=1" should always be updated/added