### PR TITLE
Overwrite provisioning playbook.yml in Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ Vagrant.configure(2) do |config|
     mkdir -p /home/vagrant/ansible/roles-ubuntu/roles
     cd /home/vagrant/ansible/roles-ubuntu
     cp -r /vagrant roles/cis
-    cat >>  playbook.yml << 'EOF'
+    cat >  playbook.yml << 'EOF'
 ---
 - hosts: 127.0.0.1
   connection: local


### PR DESCRIPTION
This fixes a problem where, if `vagrant provision` is run more than once, the inline script from the Vagrantfile would append the existing contents the `playbook.yml` with another copy of the same script. After multiple copies have been redirected to `playbook.yml`, a YAML syntax error results. i.e. The following output will come from a second `vagrant provision` run:
```
==> default: ERROR! Syntax Error while loading YAML.
==> default: 
==> default: 
==> default: The error appears to have been in '/home/vagrant/ansible/roles-ubuntu/playbook.yml': line 6, column 1, but may
==> default: be elsewhere in the file depending on the exact syntax problem.
==> default: 
==> default: The offending line appears to be:
==> default: 
==> default:     - cis
==> default: ---
==> default: ^ here
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.
```

This PR changes the inline script so that `playbook.yml` will be overwritten each time `vagrant provision` is called.